### PR TITLE
Makefile: fix stray \ warnings with grep-3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(if $(findstring $(space),$(TOPDIR)),$(error ERROR: The path to the OpenWrt dir
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep -E '\/usr' -m 1)
+DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep '/usr' -m 1)
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)


### PR DESCRIPTION
We simply grep for "/usr". So no need for "-E" or "\/". Furthermore, in the new grep versions this creates warnings.

As written in the grep-3.8 announcement:
  Regular expressions with stray backslashes now cause warnings, as
  their unspecified behavior can lead to unexpected results.
  For example, '\a' and 'a' are not always equivalent
  <https://bugs.gnu.org/39678>.

Fixes warnings in the form of:
  grep: warning: stray \ before /

Signed-off-by: Nick Hainke <vincent@systemli.org>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
